### PR TITLE
gstavidemux: set the Annex-B bytestream caps with H264 without extradata

### DIFF
--- a/gst/avi/gstavidemux.c
+++ b/gst/avi/gstavidemux.c
@@ -1947,6 +1947,10 @@ gst_avi_demux_check_caps (GstAviDemux * avi, GstCaps * caps)
             "alignment", G_TYPE_STRING, "au", NULL);
       }
     }
+  } else {
+    /* Let know downstream that the stream is an annex-b bytestream instead of avc */
+    gst_structure_set (s, "stream-format", G_TYPE_STRING, "byte-stream",
+      "alignment", G_TYPE_STRING, "au", NULL);
   }
 
   return caps;


### PR DESCRIPTION
An H264 stream without extradata can only in Annex-B format instead of AVC
so let downstream know that to put a parser when a conversion is needed