### PR TITLE
Make sure the size if valid after calling gst_pad_query_peer_duration…

### DIFF
--- a/gst/isomp4/qtdemux.c
+++ b/gst/isomp4/qtdemux.c
@@ -8554,6 +8554,14 @@ gst_qtdemux_guess_bitrate (GstQTDemux * qtdemux)
     return;
   }
 
+  /* Check that the size is valid */
+  if (size < 0) {
+    GST_DEBUG_OBJECT (qtdemux,
+        "Size in bytes of the stream not known (%" G_GINT64_FORMAT
+        ") - bailing", size);
+    return;
+  }
+
   /* Subtract the header size */
   GST_DEBUG_OBJECT (qtdemux, "Total size %" G_GINT64_FORMAT ", header size %u",
       size, qtdemux->header_size);


### PR DESCRIPTION
… when guessing the bitrate