### PR TITLE
aacparse: Support he-aac streams with PCE

### DIFF
--- a/gst/audioparsers/Makefile.am
+++ b/gst/audioparsers/Makefile.am
@@ -17,4 +17,4 @@ libgstaudioparsers_la_LIBTOOLFLAGS = --tag=disable-static
 endif
 
 noinst_HEADERS = gstaacparse.h gstamrparse.h gstac3parse.h \
-	gstdcaparse.h gstflacparse.h gstmpegaudioparse.h
+	gstdcaparse.h gstflacparse.h gstmpegaudioparse.h get_bits.h put_bits.h

--- a/gst/audioparsers/get_bits.h
+++ b/gst/audioparsers/get_bits.h
@@ -1,0 +1,756 @@
+/* This file is taken from ffmpeg/libavcodec
+ *
+ * Copyright (C) 2018 Fluendo S.A
+ * Contact: support@fluendo.com
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#ifndef AVCODEC_GET_BITS_H
+#define AVCODEC_GET_BITS_H
+
+#include <stdint.h>
+
+/* Macros to adapt this header to gstreamer: */
+#define av_assert2 g_assert
+
+#define AV_RL32    GST_READ_UINT32_LE
+#define AV_RB32    GST_READ_UINT32_BE
+#define AV_RL64    GST_READ_UINT64_LE
+#define AV_RB64    GST_READ_UINT64_BE
+
+#define AV_LOG_INFO GST_INFO
+#define AV_LOG_DEBUG GST_DEBUG
+#define AVERROR_INVALIDDATA -1
+#define av_log(_unused, logmeth, ...)  logmeth (__VA_ARGS__)
+#define av_const
+#define av_unused
+#define av_always_inline inline
+#define NEG_USR32(a,s) (((uint32_t)(a))>>(32-(s)))
+
+
+#define av_clip av_clip_c
+
+static inline av_const unsigned zero_extend(unsigned val, unsigned bits)
+{
+    return (val << ((8 * sizeof(int)) - bits)) >> ((8 * sizeof(int)) - bits);
+}
+
+/**
+ * Clip a signed integer value into the amin-amax range.
+ * @param a value to clip
+ * @param amin minimum value of the clip range
+ * @param amax maximum value of the clip range
+ * @return clipped value
+ */
+static av_always_inline av_const int av_clip_c(int a, int amin, int amax)
+{
+#if defined(HAVE_AV_CONFIG_H) && defined(ASSERT_LEVEL) && ASSERT_LEVEL >= 2
+    if (amin > amax) abort();
+#endif
+    if      (a < amin) return amin;
+    else if (a > amax) return amax;
+    else               return a;
+}
+
+/*
+ * Safe bitstream reading:
+ * optionally, the get_bits API can check to ensure that we
+ * don't read past input buffer boundaries. This is protected
+ * with CONFIG_SAFE_BITSTREAM_READER at the global level, and
+ * then below that with UNCHECKED_BITSTREAM_READER at the per-
+ * decoder level. This means that decoders that check internally
+ * can "#define UNCHECKED_BITSTREAM_READER 1" to disable
+ * overread checks.
+ * Boundary checking causes a minor performance penalty so for
+ * applications that won't want/need this, it can be disabled
+ * globally using "#define CONFIG_SAFE_BITSTREAM_READER 0".
+ */
+#ifndef UNCHECKED_BITSTREAM_READER
+#define UNCHECKED_BITSTREAM_READER !CONFIG_SAFE_BITSTREAM_READER
+#endif
+
+typedef struct GetBitContext {
+    const uint8_t *buffer, *buffer_end;
+    int index;
+    int size_in_bits;
+    int size_in_bits_plus8;
+} GetBitContext;
+
+#define VLC_TYPE int16_t
+
+typedef struct VLC {
+    int bits;
+    VLC_TYPE (*table)[2]; ///< code, bits
+    int table_size, table_allocated;
+} VLC;
+
+typedef struct RL_VLC_ELEM {
+    int16_t level;
+    int8_t len;
+    uint8_t run;
+} RL_VLC_ELEM;
+
+/* Bitstream reader API docs:
+ * name
+ *   arbitrary name which is used as prefix for the internal variables
+ *
+ * gb
+ *   getbitcontext
+ *
+ * OPEN_READER(name, gb)
+ *   load gb into local variables
+ *
+ * CLOSE_READER(name, gb)
+ *   store local vars in gb
+ *
+ * UPDATE_CACHE(name, gb)
+ *   Refill the internal cache from the bitstream.
+ *   After this call at least MIN_CACHE_BITS will be available.
+ *
+ * GET_CACHE(name, gb)
+ *   Will output the contents of the internal cache,
+ *   next bit is MSB of 32 or 64 bit (FIXME 64bit).
+ *
+ * SHOW_UBITS(name, gb, num)
+ *   Will return the next num bits.
+ *
+ * SHOW_SBITS(name, gb, num)
+ *   Will return the next num bits and do sign extension.
+ *
+ * SKIP_BITS(name, gb, num)
+ *   Will skip over the next num bits.
+ *   Note, this is equivalent to SKIP_CACHE; SKIP_COUNTER.
+ *
+ * SKIP_CACHE(name, gb, num)
+ *   Will remove the next num bits from the cache (note SKIP_COUNTER
+ *   MUST be called before UPDATE_CACHE / CLOSE_READER).
+ *
+ * SKIP_COUNTER(name, gb, num)
+ *   Will increment the internal bit counter (see SKIP_CACHE & SKIP_BITS).
+ *
+ * LAST_SKIP_BITS(name, gb, num)
+ *   Like SKIP_BITS, to be used if next call is UPDATE_CACHE or CLOSE_READER.
+ *
+ * BITS_LEFT(name, gb)
+ *   Return the number of bits left
+ *
+ * For examples see get_bits, show_bits, skip_bits, get_vlc.
+ */
+
+#ifdef LONG_BITSTREAM_READER
+#   define MIN_CACHE_BITS 32
+#else
+#   define MIN_CACHE_BITS 25
+#endif
+
+#define OPEN_READER_NOSIZE(name, gb)            \
+    unsigned int name ## _index = (gb)->index;  \
+    unsigned int av_unused name ## _cache
+
+#if UNCHECKED_BITSTREAM_READER
+#define OPEN_READER(name, gb) OPEN_READER_NOSIZE(name, gb)
+
+#define BITS_AVAILABLE(name, gb) 1
+#else
+#define OPEN_READER(name, gb)                   \
+    OPEN_READER_NOSIZE(name, gb);               \
+    unsigned int name ## _size_plus8 = (gb)->size_in_bits_plus8
+
+#define BITS_AVAILABLE(name, gb) name ## _index < name ## _size_plus8
+#endif
+
+#define CLOSE_READER(name, gb) (gb)->index = name ## _index
+
+# ifdef LONG_BITSTREAM_READER
+
+# define UPDATE_CACHE_LE(name, gb) name ## _cache = \
+      AV_RL64((gb)->buffer + (name ## _index >> 3)) >> (name ## _index & 7)
+
+# define UPDATE_CACHE_BE(name, gb) name ## _cache = \
+      AV_RB64((gb)->buffer + (name ## _index >> 3)) >> (32 - (name ## _index & 7))
+
+#else
+
+# define UPDATE_CACHE_LE(name, gb) name ## _cache = \
+      AV_RL32((gb)->buffer + (name ## _index >> 3)) >> (name ## _index & 7)
+
+# define UPDATE_CACHE_BE(name, gb) name ## _cache = \
+      AV_RB32((gb)->buffer + (name ## _index >> 3)) << (name ## _index & 7)
+
+#endif
+
+
+#ifdef BITSTREAM_READER_LE
+
+# define UPDATE_CACHE(name, gb) UPDATE_CACHE_LE(name, gb)
+
+# define SKIP_CACHE(name, gb, num) name ## _cache >>= (num)
+
+#else
+
+# define UPDATE_CACHE(name, gb) UPDATE_CACHE_BE(name, gb)
+
+# define SKIP_CACHE(name, gb, num) name ## _cache <<= (num)
+
+#endif
+
+#if UNCHECKED_BITSTREAM_READER
+#   define SKIP_COUNTER(name, gb, num) name ## _index += (num)
+#else
+#   define SKIP_COUNTER(name, gb, num) \
+    name ## _index = FFMIN(name ## _size_plus8, name ## _index + (num))
+#endif
+
+#define BITS_LEFT(name, gb) ((int)((gb)->size_in_bits - name ## _index))
+
+#define SKIP_BITS(name, gb, num)                \
+    do {                                        \
+        SKIP_CACHE(name, gb, num);              \
+        SKIP_COUNTER(name, gb, num);            \
+    } while (0)
+
+#define LAST_SKIP_BITS(name, gb, num) SKIP_COUNTER(name, gb, num)
+
+#define SHOW_UBITS_LE(name, gb, num) zero_extend(name ## _cache, num)
+#define SHOW_SBITS_LE(name, gb, num) sign_extend(name ## _cache, num)
+
+#define SHOW_UBITS_BE(name, gb, num) NEG_USR32(name ## _cache, num)
+#define SHOW_SBITS_BE(name, gb, num) NEG_SSR32(name ## _cache, num)
+
+#ifdef BITSTREAM_READER_LE
+#   define SHOW_UBITS(name, gb, num) SHOW_UBITS_LE(name, gb, num)
+#   define SHOW_SBITS(name, gb, num) SHOW_SBITS_LE(name, gb, num)
+#else
+#   define SHOW_UBITS(name, gb, num) SHOW_UBITS_BE(name, gb, num)
+#   define SHOW_SBITS(name, gb, num) SHOW_SBITS_BE(name, gb, num)
+#endif
+
+#define GET_CACHE(name, gb) ((uint32_t) name ## _cache)
+
+static inline int get_bits_count(const GetBitContext *s)
+{
+    return s->index;
+}
+
+static inline void skip_bits_long(GetBitContext *s, int n)
+{
+#if UNCHECKED_BITSTREAM_READER
+    s->index += n;
+#else
+    s->index += av_clip(n, -s->index, s->size_in_bits_plus8 - s->index);
+#endif
+}
+
+#if 0
+/**
+ * read mpeg1 dc style vlc (sign bit + mantissa with no MSB).
+ * if MSB not set it is negative
+ * @param n length in bits
+ */
+static inline int get_xbits(GetBitContext *s, int n)
+{
+    register int sign;
+    register int32_t cache;
+    OPEN_READER(re, s);
+    av_assert2(n>0 && n<=25);
+    UPDATE_CACHE(re, s);
+    cache = GET_CACHE(re, s);
+    sign  = ~cache >> 31;
+    LAST_SKIP_BITS(re, s, n);
+    CLOSE_READER(re, s);
+    return (NEG_USR32(sign ^ cache, n) ^ sign) - sign;
+}
+#endif
+
+#if 0
+static inline int get_sbits(GetBitContext *s, int n)
+{
+    register int tmp;
+    OPEN_READER(re, s);
+    av_assert2(n>0 && n<=25);
+    UPDATE_CACHE(re, s);
+    tmp = SHOW_SBITS(re, s, n);
+    LAST_SKIP_BITS(re, s, n);
+    CLOSE_READER(re, s);
+    return tmp;
+}
+#endif
+
+/**
+ * Read 1-25 bits.
+ */
+static inline unsigned int get_bits(GetBitContext *s, int n)
+{
+    register int tmp;
+    OPEN_READER(re, s);
+    av_assert2(n>0 && n<=25);
+    UPDATE_CACHE(re, s);
+    tmp = SHOW_UBITS(re, s, n);
+    LAST_SKIP_BITS(re, s, n);
+    CLOSE_READER(re, s);
+    return tmp;
+}
+
+/**
+ * Read 0-25 bits.
+ */
+static av_always_inline int get_bitsz(GetBitContext *s, int n)
+{
+    return n ? get_bits(s, n) : 0;
+}
+
+static inline unsigned int get_bits_le(GetBitContext *s, int n)
+{
+    register int tmp;
+    OPEN_READER(re, s);
+    av_assert2(n>0 && n<=25);
+    UPDATE_CACHE_LE(re, s);
+    tmp = SHOW_UBITS_LE(re, s, n);
+    LAST_SKIP_BITS(re, s, n);
+    CLOSE_READER(re, s);
+    return tmp;
+}
+
+/**
+ * Show 1-25 bits.
+ */
+static inline unsigned int show_bits(GetBitContext *s, int n)
+{
+    register int tmp;
+    OPEN_READER_NOSIZE(re, s);
+    av_assert2(n>0 && n<=25);
+    UPDATE_CACHE(re, s);
+    tmp = SHOW_UBITS(re, s, n);
+    return tmp;
+}
+
+static inline void skip_bits(GetBitContext *s, int n)
+{
+    OPEN_READER(re, s);
+    LAST_SKIP_BITS(re, s, n);
+    CLOSE_READER(re, s);
+}
+
+static inline unsigned int get_bits1(GetBitContext *s)
+{
+    unsigned int index = s->index;
+    uint8_t result     = s->buffer[index >> 3];
+#ifdef BITSTREAM_READER_LE
+    result >>= index & 7;
+    result  &= 1;
+#else
+    result <<= index & 7;
+    result >>= 8 - 1;
+#endif
+#if !UNCHECKED_BITSTREAM_READER
+    if (s->index < s->size_in_bits_plus8)
+#endif
+        index++;
+    s->index = index;
+
+    return result;
+}
+
+static inline unsigned int show_bits1(GetBitContext *s)
+{
+    return show_bits(s, 1);
+}
+
+static inline void skip_bits1(GetBitContext *s)
+{
+    skip_bits(s, 1);
+}
+
+/**
+ * Read 0-32 bits.
+ */
+static inline unsigned int get_bits_long(GetBitContext *s, int n)
+{
+    if (!n) {
+        return 0;
+    } else if (n <= MIN_CACHE_BITS) {
+        return get_bits(s, n);
+    } else {
+#ifdef BITSTREAM_READER_LE
+        unsigned ret = get_bits(s, 16);
+        return ret | (get_bits(s, n - 16) << 16);
+#else
+        unsigned ret = get_bits(s, 16) << (n - 16);
+        return ret | get_bits(s, n - 16);
+#endif
+    }
+}
+
+/**
+ * Read 0-64 bits.
+ */
+static inline uint64_t get_bits64(GetBitContext *s, int n)
+{
+    if (n <= 32) {
+        return get_bits_long(s, n);
+    } else {
+#ifdef BITSTREAM_READER_LE
+        uint64_t ret = get_bits_long(s, 32);
+        return ret | (uint64_t) get_bits_long(s, n - 32) << 32;
+#else
+        uint64_t ret = (uint64_t) get_bits_long(s, n - 32) << 32;
+        return ret | get_bits_long(s, 32);
+#endif
+    }
+}
+
+#if 0
+/**
+ * Read 0-32 bits as a signed integer.
+ */
+static inline int get_sbits_long(GetBitContext *s, int n)
+{
+    // sign_extend(x, 0) is undefined
+    if (!n)
+        return 0;
+
+    return sign_extend(get_bits_long(s, n), n);
+}
+#endif
+
+/**
+ * Show 0-32 bits.
+ */
+static inline unsigned int show_bits_long(GetBitContext *s, int n)
+{
+    if (n <= MIN_CACHE_BITS) {
+        return show_bits(s, n);
+    } else {
+        GetBitContext gb = *s;
+        return get_bits_long(&gb, n);
+    }
+}
+
+static inline int check_marker(GetBitContext *s, const char *msg)
+{
+    int bit = get_bits1(s);
+    if (!bit)
+        av_log(NULL, AV_LOG_INFO, "Marker bit missing at %d of %d %s\n", get_bits_count(s) - 1, s->size_in_bits, msg);
+
+    return bit;
+}
+
+/**
+ * Initialize GetBitContext.
+ * @param buffer bitstream buffer, must be AV_INPUT_BUFFER_PADDING_SIZE bytes
+ *        larger than the actual read bits because some optimized bitstream
+ *        readers read 32 or 64 bit at once and could read over the end
+ * @param bit_size the size of the buffer in bits
+ * @return 0 on success, AVERROR_INVALIDDATA if the buffer_size would overflow.
+ */
+static inline int init_get_bits(GetBitContext *s, const uint8_t *buffer,
+                                int bit_size)
+{
+    int buffer_size;
+    int ret = 0;
+
+    if (bit_size >= INT_MAX - 7 || bit_size < 0 || !buffer) {
+        bit_size    = 0;
+        buffer      = NULL;
+        ret         = AVERROR_INVALIDDATA;
+    }
+
+    buffer_size = (bit_size + 7) >> 3;
+
+    s->buffer             = buffer;
+    s->size_in_bits       = bit_size;
+    s->size_in_bits_plus8 = bit_size + 8;
+    s->buffer_end         = buffer + buffer_size;
+    s->index              = 0;
+
+    return ret;
+}
+
+/**
+ * Initialize GetBitContext.
+ * @param buffer bitstream buffer, must be AV_INPUT_BUFFER_PADDING_SIZE bytes
+ *        larger than the actual read bits because some optimized bitstream
+ *        readers read 32 or 64 bit at once and could read over the end
+ * @param byte_size the size of the buffer in bytes
+ * @return 0 on success, AVERROR_INVALIDDATA if the buffer_size would overflow.
+ */
+static inline int init_get_bits8(GetBitContext *s, const uint8_t *buffer,
+                                 int byte_size)
+{
+    if (byte_size > INT_MAX / 8 || byte_size < 0)
+        byte_size = -1;
+    return init_get_bits(s, buffer, byte_size * 8);
+}
+
+static inline const uint8_t *align_get_bits(GetBitContext *s)
+{
+    int n = -get_bits_count(s) & 7;
+    if (n)
+        skip_bits(s, n);
+    return s->buffer + (s->index >> 3);
+}
+
+#define init_vlc(vlc, nb_bits, nb_codes,                \
+                 bits, bits_wrap, bits_size,            \
+                 codes, codes_wrap, codes_size,         \
+                 flags)                                 \
+    ff_init_vlc_sparse(vlc, nb_bits, nb_codes,          \
+                       bits, bits_wrap, bits_size,      \
+                       codes, codes_wrap, codes_size,   \
+                       NULL, 0, 0, flags)
+
+int ff_init_vlc_sparse(VLC *vlc, int nb_bits, int nb_codes,
+                       const void *bits, int bits_wrap, int bits_size,
+                       const void *codes, int codes_wrap, int codes_size,
+                       const void *symbols, int symbols_wrap, int symbols_size,
+                       int flags);
+void ff_free_vlc(VLC *vlc);
+
+#define INIT_VLC_LE             2
+#define INIT_VLC_USE_NEW_STATIC 4
+
+#define INIT_VLC_STATIC(vlc, bits, a, b, c, d, e, f, g, static_size)       \
+    do {                                                                   \
+        static VLC_TYPE table[static_size][2];                             \
+        (vlc)->table           = table;                                    \
+        (vlc)->table_allocated = static_size;                              \
+        init_vlc(vlc, bits, a, b, c, d, e, f, g, INIT_VLC_USE_NEW_STATIC); \
+    } while (0)
+
+/**
+ * If the vlc code is invalid and max_depth=1, then no bits will be removed.
+ * If the vlc code is invalid and max_depth>1, then the number of bits removed
+ * is undefined.
+ */
+#define GET_VLC(code, name, gb, table, bits, max_depth)         \
+    do {                                                        \
+        int n, nb_bits;                                         \
+        unsigned int index;                                     \
+                                                                \
+        index = SHOW_UBITS(name, gb, bits);                     \
+        code  = table[index][0];                                \
+        n     = table[index][1];                                \
+                                                                \
+        if (max_depth > 1 && n < 0) {                           \
+            LAST_SKIP_BITS(name, gb, bits);                     \
+            UPDATE_CACHE(name, gb);                             \
+                                                                \
+            nb_bits = -n;                                       \
+                                                                \
+            index = SHOW_UBITS(name, gb, nb_bits) + code;       \
+            code  = table[index][0];                            \
+            n     = table[index][1];                            \
+            if (max_depth > 2 && n < 0) {                       \
+                LAST_SKIP_BITS(name, gb, nb_bits);              \
+                UPDATE_CACHE(name, gb);                         \
+                                                                \
+                nb_bits = -n;                                   \
+                                                                \
+                index = SHOW_UBITS(name, gb, nb_bits) + code;   \
+                code  = table[index][0];                        \
+                n     = table[index][1];                        \
+            }                                                   \
+        }                                                       \
+        SKIP_BITS(name, gb, n);                                 \
+    } while (0)
+
+#define GET_RL_VLC_INTERNAL(level, run, name, gb, table, bits,  \
+                   max_depth, need_update)                      \
+    do {                                                        \
+        int n, nb_bits;                                         \
+        unsigned int index;                                     \
+                                                                \
+        index = SHOW_UBITS(name, gb, bits);                     \
+        level = table[index].level;                             \
+        n     = table[index].len;                               \
+                                                                \
+        if (max_depth > 1 && n < 0) {                           \
+            SKIP_BITS(name, gb, bits);                          \
+            if (need_update) {                                  \
+                UPDATE_CACHE(name, gb);                         \
+            }                                                   \
+                                                                \
+            nb_bits = -n;                                       \
+                                                                \
+            index = SHOW_UBITS(name, gb, nb_bits) + level;      \
+            level = table[index].level;                         \
+            n     = table[index].len;                           \
+            if (max_depth > 2 && n < 0) {                       \
+                LAST_SKIP_BITS(name, gb, nb_bits);              \
+                if (need_update) {                              \
+                    UPDATE_CACHE(name, gb);                     \
+                }                                               \
+                nb_bits = -n;                                   \
+                                                                \
+                index = SHOW_UBITS(name, gb, nb_bits) + level;  \
+                level = table[index].level;                     \
+                n     = table[index].len;                       \
+            }                                                   \
+        }                                                       \
+        run = table[index].run;                                 \
+        SKIP_BITS(name, gb, n);                                 \
+    } while (0)
+
+/**
+ * Parse a vlc code.
+ * @param bits is the number of bits which will be read at once, must be
+ *             identical to nb_bits in init_vlc()
+ * @param max_depth is the number of times bits bits must be read to completely
+ *                  read the longest vlc code
+ *                  = (max_vlc_length + bits - 1) / bits
+ * @returns the code parsed or -1 if no vlc matches
+ */
+static av_always_inline int get_vlc2(GetBitContext *s, VLC_TYPE (*table)[2],
+                                     int bits, int max_depth)
+{
+    int code;
+
+    OPEN_READER(re, s);
+    UPDATE_CACHE(re, s);
+
+    GET_VLC(code, re, s, table, bits, max_depth);
+
+    CLOSE_READER(re, s);
+
+    return code;
+}
+
+static inline int decode012(GetBitContext *gb)
+{
+    int n;
+    n = get_bits1(gb);
+    if (n == 0)
+        return 0;
+    else
+        return get_bits1(gb) + 1;
+}
+
+static inline int decode210(GetBitContext *gb)
+{
+    if (get_bits1(gb))
+        return 0;
+    else
+        return 2 - get_bits1(gb);
+}
+
+static inline int get_bits_left(GetBitContext *gb)
+{
+    return gb->size_in_bits - get_bits_count(gb);
+}
+
+static inline int skip_1stop_8data_bits(GetBitContext *gb)
+{
+    if (get_bits_left(gb) <= 0)
+        return AVERROR_INVALIDDATA;
+
+    while (get_bits1(gb)) {
+        skip_bits(gb, 8);
+        if (get_bits_left(gb) <= 0)
+            return AVERROR_INVALIDDATA;
+    }
+
+    return 0;
+}
+
+//#define TRACE
+
+#ifdef TRACE
+static inline void print_bin(int bits, int n)
+{
+    int i;
+
+    for (i = n - 1; i >= 0; i--)
+        av_log(NULL, AV_LOG_DEBUG, "%d", (bits >> i) & 1);
+    for (i = n; i < 24; i++)
+        av_log(NULL, AV_LOG_DEBUG, " ");
+}
+
+static inline int get_bits_trace(GetBitContext *s, int n, const char *file,
+                                 const char *func, int line)
+{
+    int r = get_bits(s, n);
+
+    print_bin(r, n);
+    av_log(NULL, AV_LOG_DEBUG, "%5d %2d %3d bit @%5d in %s %s:%d\n",
+           r, n, r, get_bits_count(s) - n, file, func, line);
+
+    return r;
+}
+
+static inline int get_vlc_trace(GetBitContext *s, VLC_TYPE (*table)[2],
+                                int bits, int max_depth, const char *file,
+                                const char *func, int line)
+{
+    int show  = show_bits(s, 24);
+    int pos   = get_bits_count(s);
+    int r     = get_vlc2(s, table, bits, max_depth);
+    int len   = get_bits_count(s) - pos;
+    int bits2 = show >> (24 - len);
+
+    print_bin(bits2, len);
+
+    av_log(NULL, AV_LOG_DEBUG, "%5d %2d %3d vlc @%5d in %s %s:%d\n",
+           bits2, len, r, pos, file, func, line);
+
+    return r;
+}
+
+#define GET_RL_VLC(level, run, name, gb, table, bits,           \
+                   max_depth, need_update)                      \
+    do {                                                        \
+        int show  = SHOW_UBITS(name, gb, 24);                   \
+        int len;                                                \
+        int pos = name ## _index;                               \
+                                                                \
+        GET_RL_VLC_INTERNAL(level, run, name, gb, table, bits,max_depth, need_update); \
+                                                                \
+        len = name ## _index - pos + 1;                         \
+        show = show >> (24 - len);                              \
+                                                                \
+        print_bin(show, len);                                   \
+                                                                \
+        av_log(NULL, AV_LOG_DEBUG, "%5d %2d %3d/%-3d rlv @%5d in %s %s:%d\n",\
+               show, len, run-1, level, pos, __FILE__, __PRETTY_FUNCTION__, __LINE__);\
+    } while (0)                                                 \
+
+
+#if 0
+static inline int get_xbits_trace(GetBitContext *s, int n, const char *file,
+                                  const char *func, int line)
+{
+    int show = show_bits(s, n);
+    int r    = get_xbits(s, n);
+
+    print_bin(show, n);
+    av_log(NULL, AV_LOG_DEBUG, "%5d %2d %3d xbt @%5d in %s %s:%d\n",
+           show, n, r, get_bits_count(s) - n, file, func, line);
+
+    return r;
+}
+#endif
+
+#define get_bits(s, n)  get_bits_trace(s , n, __FILE__, __PRETTY_FUNCTION__, __LINE__)
+#define get_bits1(s)    get_bits_trace(s,  1, __FILE__, __PRETTY_FUNCTION__, __LINE__)
+#define get_xbits(s, n) get_xbits_trace(s, n, __FILE__, __PRETTY_FUNCTION__, __LINE__)
+
+#define get_vlc(s, vlc)             get_vlc_trace(s, (vlc)->table, (vlc)->bits,   3, __FILE__, __PRETTY_FUNCTION__, __LINE__)
+#define get_vlc2(s, tab, bits, max) get_vlc_trace(s,          tab,        bits, max, __FILE__, __PRETTY_FUNCTION__, __LINE__)
+#else //TRACE
+#define GET_RL_VLC GET_RL_VLC_INTERNAL
+#endif
+
+#endif /* AVCODEC_GET_BITS_H */

--- a/gst/audioparsers/gstaacparse.c
+++ b/gst/audioparsers/gstaacparse.c
@@ -68,6 +68,8 @@ GST_DEBUG_CATEGORY_STATIC (aacparse_debug);
 #define ADTS_MAX_SIZE 10        /* Should be enough */
 #define LOAS_MAX_SIZE 3         /* Should be enough */
 
+#define MAX_PCE_SIZE 40
+#define AAC_ADTS_HEADER_SIZE 7
 
 #define AAC_FRAME_DURATION(parse) (GST_SECOND/parse->frames_per_sec)
 
@@ -105,7 +107,7 @@ static inline gint
 gst_aac_parse_get_sample_rate_from_index (guint sr_idx)
 {
   static const guint aac_sample_rates[] = { 96000, 88200, 64000, 48000, 44100,
-    32000, 24000, 22050, 16000, 12000, 11025, 8000
+    32000, 24000, 22050, 16000, 12000, 11025, 8000, 7350
   };
 
   if (sr_idx < G_N_ELEMENTS (aac_sample_rates))
@@ -218,23 +220,10 @@ gst_aac_parse_set_src_caps (GstAacParse * aacparse, GstCaps * sink_caps)
   if (stream_format) {
     gst_structure_set (s, "stream-format", G_TYPE_STRING, stream_format, NULL);
 
-    if (aacparse->header_type == DSPAAC_HEADER_ADTS) {
-      int ch_config = (aacparse->codec_data[1] >> 3) & 0xf;
-      if (ch_config) {
-        GstBuffer *codec_data = gst_buffer_new_and_alloc (2);
-        GST_BUFFER_DATA (codec_data)[0] = aacparse->codec_data[0];
-        GST_BUFFER_DATA (codec_data)[1] = aacparse->codec_data[1];
-
-        gst_structure_set (s, "codec_data", GST_TYPE_BUFFER, codec_data, NULL);
-      }
-      /* FIXME: We're lacking implementation of PCE case. In this case
-         (if ch_config == 0, we MUST also attach to codec_data some bytes from
-         parsing the PCE.
-
-         See code of ffmpeg:
-         libavcodec/aac_adtstoasc_bsf.c : aac_adtstoasc_filter ()
-         libavcodec/mpeg4audio.c : avpriv_copy_pce_data ()
-       */
+    if (aacparse->header_type == DSPAAC_HEADER_ADTS && aacparse->codec_data) {
+      gst_structure_set (s, "codec_data", GST_TYPE_BUFFER,
+          aacparse->codec_data, NULL);
+      aacparse->codec_data = NULL;      /* Delegated the ownership */
     }
   }
 
@@ -689,17 +678,71 @@ gst_aac_parse_check_loas_frame (GstAacParse * aacparse,
   return FALSE;
 }
 
-/* caller ensure sufficient data */
-static inline void
-gst_aac_parse_parse_adts_header (const guint8 * data,
-    gint * rate, gint * channels, gint * object, gint * version,
-    guchar codec_data[2])
+/* Taken from ffmpeg/libavcodec/mpeg4audio.c: avpriv_copy_pce_data()
+   + headers to support bitstream reading/writing */
+#include "get_bits.h"
+#include "put_bits.h"
+static unsigned int
+copy_bits (PutBitContext * pb, GetBitContext * gb, int bits)
 {
+  unsigned int el = get_bits (gb, bits);
+  put_bits (pb, bits, el);
+  return el;
+}
+
+static int
+gst_aacparse_copy_pce_data (PutBitContext * pb, GetBitContext * gb, gint * rate,
+    gint * channels)
+{
+  int five_bit_ch, four_bit_ch, comment_size, bits;
+  int offset = put_bits_count (pb);
+
+  copy_bits (pb, gb, 6);        //Tag, Object Type
+  *rate = gst_aac_parse_get_sample_rate_from_index (copy_bits (pb, gb, 4));     // Frequency
+  five_bit_ch = copy_bits (pb, gb, 4);  //Front
+  five_bit_ch += copy_bits (pb, gb, 4); //Side
+  five_bit_ch += copy_bits (pb, gb, 4); //Back
+  four_bit_ch = copy_bits (pb, gb, 2);  //LFE
+
+  /* Front + Side + Back + LFE */
+  *channels = five_bit_ch + four_bit_ch;
+
+  four_bit_ch += copy_bits (pb, gb, 3); //Data
+  five_bit_ch += copy_bits (pb, gb, 4); //Coupling
+
+  if (copy_bits (pb, gb, 1))    //Mono Mixdown
+    copy_bits (pb, gb, 4);
+  if (copy_bits (pb, gb, 1))    //Stereo Mixdown
+    copy_bits (pb, gb, 4);
+  if (copy_bits (pb, gb, 1))    //Matrix Mixdown
+    copy_bits (pb, gb, 3);
+  for (bits = five_bit_ch * 5 + four_bit_ch * 4; bits > 16; bits -= 16)
+    copy_bits (pb, gb, 16);
+  if (bits)
+    copy_bits (pb, gb, bits);
+  avpriv_align_put_bits (pb);
+  align_get_bits (gb);
+  comment_size = copy_bits (pb, gb, 8);
+  for (; comment_size > 0; comment_size--)
+    copy_bits (pb, gb, 8);
+
+  return put_bits_count (pb) - offset;
+}
+
+
+/* caller ensure sufficient data */
+static inline gboolean
+gst_aac_parse_parse_adts_header (const guint8 * data, gsize data_size,
+    gint * rate, gint * channels, gint * object, gint * version,
+    GstBuffer * codec_data_buf)
+{
+  guint8 *codec_data;
   gint sr_idx = (data[2] & 0x3c) >> 2;
   gint ch = ((data[2] & 0x01) << 2) | ((data[3] & 0xc0) >> 6);
   gint obj = (data[2] & 0xc0) >> 6;
 
-  if (codec_data) {
+  if (codec_data_buf) {
+    codec_data = GST_BUFFER_DATA (codec_data_buf);
     /*
        5 bits: obj + 1
        4 bits: sr_idx
@@ -708,6 +751,7 @@ gst_aac_parse_parse_adts_header (const guint8 * data,
      */
     codec_data[0] = ((obj + 1) << 3) | sr_idx >> 1;
     codec_data[1] = (sr_idx << 7) | (ch << 3);
+    GST_BUFFER_SIZE (codec_data_buf) = 2;
   }
 
   if (rate)
@@ -721,6 +765,39 @@ gst_aac_parse_parse_adts_header (const guint8 * data,
 
   if (object)
     *object = obj;
+
+  if (ch)
+    return TRUE;
+
+  if (codec_data_buf) {
+    GetBitContext gb;
+    PutBitContext pb;
+    /* Jump forward through adts header */
+    /* + Skip crc checksum */
+    data += AAC_ADTS_HEADER_SIZE + 2 * !(data[1] & 0x1);
+    data_size -= AAC_ADTS_HEADER_SIZE + 2 * !(data[1] & 0x1);
+
+    if (data_size <= 0)
+      return FALSE;
+
+    /* Now we need to copy PCE data to the rest of codec_data_buf */
+    init_get_bits (&gb, data, data_size * 8);
+    init_put_bits (&pb, codec_data + 2, MAX_PCE_SIZE * 8);
+
+    if (get_bits (&gb, 3) != 5) {
+      GST_ERROR ("PCE-based channel configuration "
+          "without PCE as first syntax " "element");
+      return FALSE;
+    }
+
+    GST_BUFFER_SIZE (codec_data_buf) +=
+        gst_aacparse_copy_pce_data (&pb, &gb, rate, channels) / 8;
+    flush_put_bits (&pb);
+
+    return TRUE;
+  }
+
+  return FALSE;
 }
 
 /**
@@ -791,8 +868,27 @@ gst_aac_parse_detect_stream (GstAacParse * aacparse,
 
     GST_INFO ("ADTS ID: %d, framesize: %d", (data[1] & 0x08) >> 3, *framesize);
 
-    gst_aac_parse_parse_adts_header (data, &rate, &channels,
+    if (!aacparse->codec_data)
+      aacparse->codec_data = gst_buffer_new_and_alloc (2 + MAX_PCE_SIZE);
+
+    gst_aac_parse_parse_adts_header (data, avail, &rate, &channels,
         &aacparse->object_type, &aacparse->mpegversion, aacparse->codec_data);
+
+    /* If we have PCE, then we need to use rate/channels from it, because they do not
+       present in ADTS header */
+    if (GST_BUFFER_SIZE (aacparse->codec_data) > 2) {
+      GST_DEBUG_OBJECT (aacparse, "Processed PCE element:"
+          " samplerate %d, channels %d."
+          "created codec_data of size %d", rate, channels,
+          GST_BUFFER_SIZE (aacparse->codec_data));
+      /* FIXME: sampling rate from both PCE and ADTS header is incorrect
+         on some files. FFmpeg multiples sampling rate of this file on 2
+         during decoding, and it becomes correct.
+         P.S. Number of channels is also incorrect :( */
+      aacparse->have_pce = TRUE;
+      aacparse->pce_sample_rate = rate;
+      aacparse->pce_channels = channels;
+    }
 
     if (!channels || !framesize) {
       GST_DEBUG_OBJECT (aacparse, "impossible ADTS configuration");
@@ -1046,8 +1142,13 @@ gst_aac_parse_parse_frame (GstBaseParse * parse, GstBaseParseFrame * frame)
     /* see above */
     frame->overhead = 7;
 
-    gst_aac_parse_parse_adts_header (GST_BUFFER_DATA (buffer),
-        &rate, &channels, NULL, NULL, aacparse->codec_data);
+    if (aacparse->have_pce) {
+      rate = aacparse->pce_sample_rate;
+      channels = aacparse->pce_channels;
+    } else
+      gst_aac_parse_parse_adts_header (GST_BUFFER_DATA (buffer),
+          GST_BUFFER_SIZE (buffer), &rate, &channels, NULL, NULL, NULL);
+
     GST_LOG_OBJECT (aacparse, "rate: %d, chans: %d", rate, channels);
 
     if (G_UNLIKELY (rate != aacparse->sample_rate
@@ -1133,7 +1234,13 @@ gst_aac_parse_start (GstBaseParse * parse)
 static gboolean
 gst_aac_parse_stop (GstBaseParse * parse)
 {
+  GstAacParse *aacparse = GST_AAC_PARSE (parse);
   GST_DEBUG ("stop");
+  if (aacparse->codec_data) {
+    gst_buffer_unref (aacparse->codec_data);
+    aacparse->codec_data = NULL;
+  }
+  aacparse->have_pce = FALSE;
   return TRUE;
 }
 

--- a/gst/audioparsers/gstaacparse.h
+++ b/gst/audioparsers/gstaacparse.h
@@ -79,7 +79,10 @@ struct _GstAacParse {
   gint           mpegversion;
   gint           frame_samples;
 
-  guchar         codec_data[2];
+  GstBuffer      *codec_data;
+  gboolean       have_pce;
+  gint           pce_sample_rate;
+  gint           pce_channels;
 
   GstAacHeaderType header_type;
 };

--- a/gst/audioparsers/put_bits.h
+++ b/gst/audioparsers/put_bits.h
@@ -1,0 +1,284 @@
+/* This file is taken from ffmpeg/libavcodec
+ *
+ * Copyright (C) 2018 Fluendo S.A
+ * Contact: support@fluendo.com
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#ifndef AVCODEC_PUT_BITS_H
+#define AVCODEC_PUT_BITS_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+typedef struct PutBitContext {
+    uint32_t bit_buf;
+    int bit_left;
+    uint8_t *buf, *buf_ptr, *buf_end;
+    int size_in_bits;
+} PutBitContext;
+
+
+/* Some code to adapt this header for gstreamer: */
+
+#define av_assert0 g_assert
+#define AV_LOG_ERROR GST_ERROR
+#define av_log(_unused, logmeth, ...)  logmeth (__VA_ARGS__)
+#define AV_WL32    GST_WRITE_UINT32_LE
+#define AV_WB32    GST_WRITE_UINT32_BE
+
+
+static inline void put_bits(PutBitContext *s, int n, unsigned int value);
+static void avpriv_align_put_bits(PutBitContext *s)
+{
+    put_bits(s, s->bit_left & 7, 0);
+}
+
+/* --- */
+
+
+/**
+ * Initialize the PutBitContext s.
+ *
+ * @param buffer the buffer where to put bits
+ * @param buffer_size the size in bytes of buffer
+ */
+static inline void init_put_bits(PutBitContext *s, uint8_t *buffer,
+                                 int buffer_size)
+{
+    if (buffer_size < 0) {
+        buffer_size = 0;
+        buffer      = NULL;
+    }
+
+    s->size_in_bits = 8 * buffer_size;
+    s->buf          = buffer;
+    s->buf_end      = s->buf + buffer_size;
+    s->buf_ptr      = s->buf;
+    s->bit_left     = 32;
+    s->bit_buf      = 0;
+}
+
+/**
+ * Rebase the bit writer onto a reallocated buffer.
+ *
+ * @param buffer the buffer where to put bits
+ * @param buffer_size the size in bytes of buffer,
+ *                    must be larger than the previous size
+ */
+static inline void rebase_put_bits(PutBitContext *s, uint8_t *buffer,
+                                   int buffer_size)
+{
+    av_assert0(8*buffer_size > s->size_in_bits);
+
+    s->buf_end = buffer + buffer_size;
+    s->buf_ptr = buffer + (s->buf_ptr - s->buf);
+    s->buf     = buffer;
+    s->size_in_bits = 8 * buffer_size;
+}
+
+/**
+ * @return the total number of bits written to the bitstream.
+ */
+static inline int put_bits_count(PutBitContext *s)
+{
+    return (s->buf_ptr - s->buf) * 8 + 32 - s->bit_left;
+}
+
+/**
+ * @return the number of bits available in the bitstream.
+ */
+static inline int put_bits_left(PutBitContext* s)
+{
+    return (s->buf_end - s->buf_ptr) * 8 - 32 + s->bit_left;
+}
+
+/**
+ * Pad the end of the output stream with zeros.
+ */
+static inline void flush_put_bits(PutBitContext *s)
+{
+#ifndef BITSTREAM_WRITER_LE
+    if (s->bit_left < 32)
+        s->bit_buf <<= s->bit_left;
+#endif
+    while (s->bit_left < 32) {
+        av_assert0(s->buf_ptr < s->buf_end);
+#ifdef BITSTREAM_WRITER_LE
+        *s->buf_ptr++ = s->bit_buf;
+        s->bit_buf  >>= 8;
+#else
+        *s->buf_ptr++ = s->bit_buf >> 24;
+        s->bit_buf  <<= 8;
+#endif
+        s->bit_left  += 8;
+    }
+    s->bit_left = 32;
+    s->bit_buf  = 0;
+}
+
+#ifdef BITSTREAM_WRITER_LE
+#define avpriv_align_put_bits align_put_bits_unsupported_here
+#define avpriv_put_string ff_put_string_unsupported_here
+#define avpriv_copy_bits avpriv_copy_bits_unsupported_here
+#else
+/**
+ * Pad the bitstream with zeros up to the next byte boundary.
+ */
+#if 0
+void avpriv_align_put_bits(PutBitContext *s);
+#endif
+
+/**
+ * Put the string string in the bitstream.
+ *
+ * @param terminate_string 0-terminates the written string if value is 1
+ */
+void avpriv_put_string(PutBitContext *pb, const char *string,
+                       int terminate_string);
+
+/**
+ * Copy the content of src to the bitstream.
+ *
+ * @param length the number of bits of src to copy
+ */
+void avpriv_copy_bits(PutBitContext *pb, const uint8_t *src, int length);
+#endif
+
+/**
+ * Write up to 31 bits into a bitstream.
+ * Use put_bits32 to write 32 bits.
+ */
+static inline void put_bits(PutBitContext *s, int n, unsigned int value)
+{
+    unsigned int bit_buf;
+    int bit_left;
+
+    av_assert2(n <= 31 && value < (1U << n));
+
+    bit_buf  = s->bit_buf;
+    bit_left = s->bit_left;
+
+    /* XXX: optimize */
+#ifdef BITSTREAM_WRITER_LE
+    bit_buf |= value << (32 - bit_left);
+    if (n >= bit_left) {
+        if (3 < s->buf_end - s->buf_ptr) {
+            AV_WL32(s->buf_ptr, bit_buf);
+            s->buf_ptr += 4;
+        } else {
+            av_log(NULL, AV_LOG_ERROR, "Internal error, put_bits buffer too small\n");
+            av_assert2(0);
+        }
+        bit_buf     = value >> bit_left;
+        bit_left   += 32;
+    }
+    bit_left -= n;
+#else
+    if (n < bit_left) {
+        bit_buf     = (bit_buf << n) | value;
+        bit_left   -= n;
+    } else {
+        bit_buf   <<= bit_left;
+        bit_buf    |= value >> (n - bit_left);
+        if (3 < s->buf_end - s->buf_ptr) {
+            AV_WB32(s->buf_ptr, bit_buf);
+            s->buf_ptr += 4;
+        } else {
+            av_log(NULL, AV_LOG_ERROR, "Internal error, put_bits buffer too small\n");
+            av_assert2(0);
+        }
+        bit_left   += 32 - n;
+        bit_buf     = value;
+    }
+#endif
+
+    s->bit_buf  = bit_buf;
+    s->bit_left = bit_left;
+}
+
+#if 0
+static inline void put_sbits(PutBitContext *pb, int n, int32_t value)
+{
+    av_assert2(n >= 0 && n <= 31);
+
+    put_bits(pb, n, av_mod_uintp2(value, n));
+}
+#endif
+
+/**
+ * Write exactly 32 bits into a bitstream.
+ */
+static void av_unused put_bits32(PutBitContext *s, uint32_t value)
+{
+    int lo = value & 0xffff;
+    int hi = value >> 16;
+#ifdef BITSTREAM_WRITER_LE
+    put_bits(s, 16, lo);
+    put_bits(s, 16, hi);
+#else
+    put_bits(s, 16, hi);
+    put_bits(s, 16, lo);
+#endif
+}
+
+/**
+ * Return the pointer to the byte where the bitstream writer will put
+ * the next bit.
+ */
+static inline uint8_t *put_bits_ptr(PutBitContext *s)
+{
+    return s->buf_ptr;
+}
+
+/**
+ * Skip the given number of bytes.
+ * PutBitContext must be flushed & aligned to a byte boundary before calling this.
+ */
+static inline void skip_put_bytes(PutBitContext *s, int n)
+{
+    av_assert2((put_bits_count(s) & 7) == 0);
+    av_assert2(s->bit_left == 32);
+    av_assert0(n <= s->buf_end - s->buf_ptr);
+    s->buf_ptr += n;
+}
+
+/**
+ * Skip the given number of bits.
+ * Must only be used if the actual values in the bitstream do not matter.
+ * If n is 0 the behavior is undefined.
+ */
+static inline void skip_put_bits(PutBitContext *s, int n)
+{
+    s->bit_left -= n;
+    s->buf_ptr  -= 4 * (s->bit_left >> 5);
+    s->bit_left &= 31;
+}
+
+/**
+ * Change the end of the buffer.
+ *
+ * @param size the new size in bytes of the buffer where to put bits
+ */
+static inline void set_put_bits_buffer_size(PutBitContext *s, int size)
+{
+    av_assert0(size <= INT_MAX/8 - 32);
+    s->buf_end = s->buf + size;
+    s->size_in_bits = 8*size;
+}
+
+#endif /* AVCODEC_PUT_BITS_H */


### PR DESCRIPTION
Rate and channels number is incorrect still,
but it's working with some decoders, because of
codec_data provided