### PR TITLE
Fix: Fix flu tags registrations

### DIFF
--- a/gst/isomp4/isomp4-plugin.c
+++ b/gst/isomp4/isomp4-plugin.c
@@ -51,13 +51,6 @@ plugin_init (GstPlugin * plugin)
       G_TYPE_STRING, GST_QT_DEMUX_CLASSIFICATION_TAG, "content classification",
       gst_tag_merge_use_first);
 
-  gst_tag_register (FLU_SDK_TAG_AV_ENCODING, GST_TAG_FLAG_META,
-      G_TYPE_STRING, "AVComponent encoding", "OIPF 8.4.2 AVComponent encoding",
-      NULL);
-
-  gst_tag_register (FLU_SDK_TAG_AV_PID, GST_TAG_FLAG_META,
-      G_TYPE_UINT, "av pid", "OIPF 8.4.2 AVComponent pid", NULL);
-
   if (!gst_element_register (plugin, "qtdemux",
           GST_RANK_PRIMARY, GST_TYPE_QTDEMUX))
     return FALSE;

--- a/gst/isomp4/qtdemux.c
+++ b/gst/isomp4/qtdemux.c
@@ -700,6 +700,13 @@ gst_qtdemux_class_init (GstQTDemuxClass * klass)
 
   gst_tag_register_musicbrainz_tags ();
 
+  gst_tag_register (FLU_SDK_TAG_AV_ENCODING, GST_TAG_FLAG_META,
+      G_TYPE_STRING, "AVComponent encoding", "OIPF 8.4.2 AVComponent encoding",
+      NULL);
+
+  gst_tag_register (FLU_SDK_TAG_AV_PID, GST_TAG_FLAG_META,
+      G_TYPE_UINT, "av pid", "OIPF 8.4.2 AVComponent pid", NULL);
+
   gst_qtdemux_signals[SIGNAL_EMSG] =
       g_signal_new ("emsg", G_TYPE_FROM_CLASS (klass),
       G_SIGNAL_RUN_LAST, G_STRUCT_OFFSET (GstQTDemuxClass, emsg),


### PR DESCRIPTION
Register av-encoding and av-pid in gst_qtdemux_class_init
instead of isomp4-plugin_init.