### PR TITLE
fix: change the default timeout of GstSoupHTTPSrc.

### DIFF
--- a/docs/plugins/gst-plugins-good-plugins.args
+++ b/docs/plugins/gst-plugins-good-plugins.args
@@ -3785,7 +3785,7 @@
 <FLAGS>rw</FLAGS>
 <NICK>timeout</NICK>
 <BLURB>Value in seconds to timeout a blocking I/O (0 = No timeout).</BLURB>
-<DEFAULT>0</DEFAULT>
+<DEFAULT>30</DEFAULT>
 </ARG>
 
 <ARG>

--- a/ext/soup/gstsouphttpclientsink.c
+++ b/ext/soup/gstsouphttpclientsink.c
@@ -218,7 +218,7 @@ gst_soup_http_client_sink_init (GstSoupHttpClientSink * souphttpsink,
   souphttpsink->proxy_id = NULL;
   souphttpsink->proxy_pw = NULL;
   souphttpsink->prop_session = NULL;
-  souphttpsink->timeout = 1;
+  souphttpsink->timeout = 30;
   proxy = g_getenv ("http_proxy");
   if (proxy && !gst_soup_http_client_sink_set_proxy (souphttpsink, proxy)) {
     GST_WARNING_OBJECT (souphttpsink,
@@ -518,6 +518,7 @@ gst_soup_http_client_sink_start (GstBaseSink * sink)
     g_mutex_unlock (souphttpsink->mutex);
     GST_LOG_OBJECT (souphttpsink, "main loop thread running");
 
+    GST_DEBUG_OBJECT (souphttpsink, "timeout=%d", souphttpsink->timeout);
     souphttpsink->session =
         soup_session_async_new_with_options (SOUP_SESSION_ASYNC_CONTEXT,
         souphttpsink->context, SOUP_SESSION_USER_AGENT,


### PR DESCRIPTION
We are changing the default timeout of GstSoupHTTPSrc from 0 to 30 seconds.
When soup receives timeout=0 on the used deprecated async session, it uses an infinite timeout, so it only times out when socket does (may be >120 seconds depending on platform and configuration). That's too much for a HTTP connect.
Fixes test org.hbbtv_00003930, which expects a connect timeout smaller than 120 seconds.
NOTE: soup only supports a single timeout for the whole operation, this is very limited. Ideally, the main timeout should only count since last data received. We are not considering modifying soup behavior, although it would be very convenient because this is a very serious limitation that affects all soup users.