### PR TITLE
aacparse: return error if no aac stream found

### DIFF
--- a/gst/audioparsers/gstaacparse.h
+++ b/gst/audioparsers/gstaacparse.h
@@ -83,6 +83,7 @@ struct _GstAacParse {
   gboolean       have_pce;
   gint           pce_sample_rate;
   gint           pce_channels;
+  gint           buffers_failed;
 
   GstAacHeaderType header_type;
 };


### PR DESCRIPTION
Needed for case of wrongly muxed stream.
This allows a pipeline to react before
locking in a multiqueue, because aacparse
consumes data without providing any output,
and other streams are waiting for the preroll:
this causes multiqueue to get full.