### PR TITLE
qtdemux: extend max atom size

### DIFF
--- a/gst/isomp4/qtdemux.c
+++ b/gst/isomp4/qtdemux.c
@@ -88,7 +88,7 @@
 #define QTDEMUX_MAX_ATOM_SIZE (100*1024*1024)
 
 /* if the sample index is larger than this, something is likely wrong */
-#define QTDEMUX_MAX_SAMPLE_INDEX_SIZE (50*1024*1024)
+#define QTDEMUX_MAX_SAMPLE_INDEX_SIZE (100*1024*1024)
 
 /* For converting qt creation times to unix epoch times */
 #define QTDEMUX_SECONDS_PER_DAY (60 * 60 * 24)

--- a/gst/isomp4/qtdemux.c
+++ b/gst/isomp4/qtdemux.c
@@ -85,7 +85,7 @@
 #endif
 
 /* max. size considered 'sane' for non-mdat atoms */
-#define QTDEMUX_MAX_ATOM_SIZE (25*1024*1024)
+#define QTDEMUX_MAX_ATOM_SIZE (100*1024*1024)
 
 /* if the sample index is larger than this, something is likely wrong */
 #define QTDEMUX_MAX_SAMPLE_INDEX_SIZE (50*1024*1024)


### PR DESCRIPTION
We've found a file that has moov
atom of size ~38 mb.