### PR TITLE
qtdemux:fix for mp4 with moov being put to the end

### DIFF
--- a/gst/isomp4/qtdemux.h
+++ b/gst/isomp4/qtdemux.h
@@ -121,7 +121,7 @@ struct _GstQTDemux
   guint64 seek_offset;
 
   gboolean upstream_seekable;
-  gboolean upstream_size;
+  gint64 upstream_size;
 
   gint64 earliest_presentation_time;
 };


### PR DESCRIPTION
Taken from GStreamer 1.0