### PR TITLE
Change default souphttpsource timeout to 10s

### DIFF
--- a/ext/soup/gstsouphttpsrc.c
+++ b/ext/soup/gstsouphttpsrc.c
@@ -126,7 +126,7 @@ enum
 
 #define DEFAULT_USER_AGENT           "GStreamer souphttpsrc "
 #define DEFAULT_KEEP_ALIVE           FALSE
-#define DEFAULT_TIMEOUT              30
+#define DEFAULT_TIMEOUT              10
 
 static void gst_soup_http_src_uri_handler_init (gpointer g_iface,
     gpointer iface_data);


### PR DESCRIPTION
Was changed from infinite to 30s a long time ago. It was still too large and
needs to be shorter, like 10s. 10s is still a lot more than any alive server
should answer, specially for any media content.
We use a default play timeout of 30s, so if server was down, we finished with
play timeout error instead of the more specific error OPEN_FAILED from
souphttpsource.
Still this is a property default value that can be overriden if desired.